### PR TITLE
add support for page calls EPD-2744 EPD-2828

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,9 @@
+1.2.0 / 2017-05-15
+==================
+
+  * Add enableHtmlInAppMessages option
+  * Add support for page calls
+
 1.1.0 / 2017-04-27
 ==================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -78,6 +78,7 @@ Appboy.prototype.loaded = function() {
  */
 
 Appboy.prototype.identify = function(identify) {
+  var userId = identify.userId();
   var address = identify.address();
   var avatar = identify.avatar();
   var birthday = identify.birthday();
@@ -88,6 +89,7 @@ Appboy.prototype.identify = function(identify) {
   var phone = identify.phone();
   var traits = clone(identify.traits());
 
+  window.appboy.changeUser(userId);
   window.appboy.getUser().setAvatarImageUrl(avatar);
   window.appboy.getUser().setEmail(email);
   window.appboy.getUser().setFirstName(firstName);
@@ -128,7 +130,10 @@ Appboy.prototype.identify = function(identify) {
  */
 
 Appboy.prototype.group = function(group) {
+  var userId = group.userId();
   var groupIdKey = 'ab_segment_group_' + group.groupId();
+
+  window.appboy.changeUser(userId);
   window.appboy.getUser().setCustomUserAttribute(groupIdKey, true);
 };
 
@@ -142,8 +147,11 @@ Appboy.prototype.group = function(group) {
  */
 
 Appboy.prototype.track = function(track) {
+  var userId = track.userId();
   var eventName = track.event();
   var properties = track.properties();
+
+  window.appboy.changeUser(userId);
   window.appboy.logCustomEvent(eventName, properties);
 };
 
@@ -161,9 +169,12 @@ Appboy.prototype.page = function(page) {
   if (!settings.trackAllPages && !settings.trackNamedPages) return;
   if (settings.trackNamedPages && !page.name()) return;
 
+  var userId = page.userId();
   var pageEvent = page.track(page.fullName());
   var eventName = pageEvent.event();
   var properties = page.properties();
+
+  window.appboy.changeUser(userId);
   window.appboy.logCustomEvent(eventName, properties);
 };
 
@@ -180,9 +191,12 @@ Appboy.prototype.page = function(page) {
 
 
 Appboy.prototype.orderCompleted = function(track) {
+  var userId = track.userId();
   var products = track.products();
   var currencyCode = track.currency();
   var purchaseProperties = track.properties();
+
+  window.appboy.changeUser(userId);
 
   // remove reduntant properties
   del(purchaseProperties, 'products');

--- a/lib/index.js
+++ b/lib/index.js
@@ -128,11 +128,6 @@ Appboy.prototype.identify = function(identify) {
  */
 
 Appboy.prototype.group = function(group) {
-  var userId = this.analytics.user().id();
-
-  if (!userId) return;
-  window.appboy.changeUser(userId);
-
   var groupIdKey = 'ab_segment_group_' + group.groupId();
   window.appboy.getUser().setCustomUserAttribute(groupIdKey, true);
 };
@@ -163,9 +158,6 @@ Appboy.prototype.track = function(track) {
 
 Appboy.prototype.page = function(page) {
   var settings = this.options;
-  var userId = this.analytics.user().id();
-
-  if (!userId) return;
   if (!settings.trackAllPages && !settings.trackNamedPages) return;
   if (settings.trackNamedPages && !page.name()) return;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,9 @@ var Appboy = module.exports = integration('Appboy')
   .option('apiKey', '')
   .option('safariWebsitePushId', '')
   .option('automaticallyDisplayMessages', true)
+  .option('enableHtmlInAppMessages', false)
+  .option('trackAllPages', false)
+  .option('trackNamedPages', false)
   .tag('<script src="https://js.appboycdn.com/web-sdk/1.6/appboy.min.js">');
 
 /**
@@ -31,7 +34,7 @@ Appboy.prototype.initialize = function() {
   var options = this.options;
   var self = this;
   var userId = this.analytics.user().id();
-  
+
   // stub out function
   /* eslint-disable */
   +function(a,p,P,b,y) {
@@ -45,6 +48,7 @@ Appboy.prototype.initialize = function() {
   this.load(function() {
     var config = {};
     if (options.safariWebsitePushId) config.safariWebsitePushId = options.safariWebsitePushId;
+    if (options.enableHtmlInAppMessages) config.enableHtmlInAppMessages = true;
     window.appboy.initialize(options.apiKey, config);
 
     if (options.automaticallyDisplayMessages) window.appboy.display.automaticallyShowNewInAppMessages();
@@ -74,12 +78,6 @@ Appboy.prototype.loaded = function() {
  */
 
 Appboy.prototype.identify = function(identify) {
-  var userId = identify.userId();
-  // Appboy doesn't want you to call changeUser unless a userId is present because they do automatic anonymous user tracking on their end 
-  // https://www.appboy.com/documentation/Web/#setting-user-ids
-  if (!userId) return;
-  window.appboy.changeUser(userId);
-
   var address = identify.address();
   var avatar = identify.avatar();
   var birthday = identify.birthday();
@@ -151,6 +149,29 @@ Appboy.prototype.group = function(group) {
 Appboy.prototype.track = function(track) {
   var eventName = track.event();
   var properties = track.properties();
+  window.appboy.logCustomEvent(eventName, properties);
+};
+
+/**
+ * Page.
+ *
+ * https://js.appboycdn.com/web-sdk/latest/doc/module-appboy.html#.logCustomEvent
+ *
+ * @api public
+ * @param {Page} page
+ */
+
+Appboy.prototype.page = function(page) {
+  var settings = this.options;
+  var userId = this.analytics.user().id();
+
+  if (!userId) return;
+  if (!settings.trackAllPages && !settings.trackNamedPages) return;
+  if (settings.trackNamedPages && !page.name()) return;
+
+  var pageEvent = page.track(page.fullName());
+  var eventName = pageEvent.event();
+  var properties = page.properties();
   window.appboy.logCustomEvent(eventName, properties);
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-appboy",
   "description": "The Appboy analytics.js integration.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -91,6 +91,7 @@ describe('Appboy', function() {
 
     describe('#identify', function() {
       beforeEach(function() {
+        analytics.stub(window.appboy, 'changeUser');
         analytics.stub(window.appboy.ab.User.prototype, 'setFirstName');
         analytics.stub(window.appboy.ab.User.prototype, 'setLastName');
         analytics.stub(window.appboy.ab.User.prototype, 'setPhoneNumber');
@@ -117,6 +118,7 @@ describe('Appboy', function() {
             country: 'Ireland'
           }
         });
+        analytics.called(window.appboy.changeUser, 'userId');
         analytics.called(window.appboy.ab.User.prototype.setAvatarImageUrl, 'https://s-media-cache-ak0.pinimg.com/736x/39/b9/75/39b9757ac27c6eabba292d71a63def2c.jpg');
         analytics.called(window.appboy.ab.User.prototype.setCountry, 'Ireland');
         analytics.called(window.appboy.ab.User.prototype.setDateOfBirth, 1991, 9, 16);
@@ -132,6 +134,7 @@ describe('Appboy', function() {
         analytics.identify('userId', {
           gender: 'male'
         });
+        analytics.called(window.appboy.changeUser, 'userId');
         analytics.called(window.appboy.ab.User.prototype.setGender, window.appboy.ab.User.Genders.MALE);
       });
 
@@ -139,6 +142,7 @@ describe('Appboy', function() {
         analytics.identify('userId', {
           gender: 'o'
         });
+        analytics.called(window.appboy.changeUser, 'userId');
         analytics.called(window.appboy.ab.User.prototype.setGender, window.appboy.ab.User.Genders.OTHER);
       });
 
@@ -149,6 +153,7 @@ describe('Appboy', function() {
           number: 16,
           date: 'Tue Apr 25 2017 14:22:48 GMT-0700 (PDT)'
         });
+        analytics.called(window.appboy.changeUser, 'userId');
         analytics.called(window.appboy.ab.User.prototype.setCustomUserAttribute, 'song', 'Who\'s That Chick?');
         analytics.called(window.appboy.ab.User.prototype.setCustomUserAttribute, 'artists', ['David Guetta', 'Rihanna']);
         analytics.called(window.appboy.ab.User.prototype.setCustomUserAttribute, 'number', 16);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -158,8 +158,6 @@ describe('Appboy', function() {
 
     describe('#group', function() {
       beforeEach(function() {
-        analytics.user().identify('userId');
-        analytics.stub(window.appboy, 'changeUser');
         analytics.stub(window.appboy.ab.User.prototype, 'setCustomUserAttribute');
       });
 
@@ -167,7 +165,6 @@ describe('Appboy', function() {
         analytics.group('0e8c78ea9d97a7b8185e8632', {
           name: 'Initech'
         });
-        analytics.called(window.appboy.changeUser, 'userId');
         analytics.called(window.appboy.ab.User.prototype.setCustomUserAttribute, 'ab_segment_group_0e8c78ea9d97a7b8185e8632', true);
       });
     });
@@ -253,7 +250,6 @@ describe('Appboy', function() {
 
     describe('#page', function() {
       beforeEach(function() {
-        analytics.user().identify('userId');
         analytics.stub(window.appboy, 'logCustomEvent');
       });
 


### PR DESCRIPTION
This PR:

- adds support for page calls 
- adds an option for users to enable HTML In App Messages when Appboy loads
- removes `changeUser` from identify and group calls so users can set attributes on anonymous users

server side PR for parity: https://github.com/segment-integrations/integration-appboy/pull/38