### PR TITLE
Enable setting datacenter to EU

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,4 @@
-1.2.2 / 2017-07-05
+1.3.0 / 2017-07-05
 ==================
 
   * Switch the endpoint when datacenter is set to 'eu' 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+1.2.2 / 2017-07-05
+==================
+
+  * Switch the endpoint when datacenter is set to 'eu' 
+
 1.2.1 / 2017-06-26
 ==================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,6 +49,7 @@ Appboy.prototype.initialize = function() {
     var config = {};
     if (options.safariWebsitePushId) config.safariWebsitePushId = options.safariWebsitePushId;
     if (options.enableHtmlInAppMessages) config.enableHtmlInAppMessages = true;
+    if (options.datacenter === 'eu') config.baseUrl = 'https://sdk.api.appboy.eu/api/v3';
     window.appboy.initialize(options.apiKey, config);
 
     if (options.automaticallyDisplayMessages) window.appboy.display.automaticallyShowNewInAppMessages();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-appboy",
   "description": "The Appboy analytics.js integration.",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-appboy",
   "description": "The Appboy analytics.js integration.",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",


### PR DESCRIPTION
Per this section: https://cl.ly/0G2w3N0q3l1X
Of this doc: https://www.appboy.com/documentation/FAQs/#im-using-the-eu-data-center-what-do-i-need-to-do-differently

This should allow a user to properly route their data when they have chosen the EU datacenter.