### PR TITLE
Add customEndpoint suffix and prefix logic

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -52,7 +52,9 @@ Appboy.prototype.initialize = function() {
 
     // Setup custom endpoints
     if (options.customEndpoint) {
-      config.baseUrl = options.customEndpoint;
+      var endpoint = options.customEndpoint;
+      var regex = new RegExp('^(http|https)://', 'i');
+      config.baseUrl = (regex.test(endpoint) ? endpoint : 'https://' + endpoint) + '/api/v3';
     } else if (options.datacenter === 'eu') {
       config.baseUrl = 'https://sdk.api.appboy.eu/api/v3';
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -85,7 +85,21 @@ describe('Appboy', function() {
       var spy = sinon.spy(appboy, 'initializeTester');
       analytics.once('ready', function() {
         try {
-          assert.equal(spy.args[0][1].baseUrl, 'https://my.custom.endpoint.com');
+          assert.equal(spy.args[0][1].baseUrl, 'https://my.custom.endpoint.com/api/v3');
+          done();
+        } catch (e) {
+          done(e);
+        }
+      });
+      analytics.initialize();
+    });
+
+    it('should prefix the customEndpoint with https:// if it was not by the user', function(done) {
+      appboy.options.customEndpoint = 'my.custom.endpoint.com';
+      var spy = sinon.spy(appboy, 'initializeTester');
+      analytics.once('ready', function() {
+        try {
+          assert.equal(spy.args[0][1].baseUrl, 'https://my.custom.endpoint.com/api/v3');
           done();
         } catch (e) {
           done(e);


### PR DESCRIPTION
The Appboy team has said that the custom endpoint will be given to user's in a format like: `sdk.api.appboy.eu`

We therefore will need to prefix it with https and suffix it with the path `/api/v3`. This PR does that with an extra test to see if the user actually input https by themselves.