### PR TITLE
Support Braze addAlias

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -209,6 +209,19 @@ Appboy.prototype.identify = function(identify) {
 };
 
 /**
+ * Alias.
+ *
+ * Add an alias ID to an existing user ID.
+ *
+ * @api public
+ * @param {Alias} alias
+ */
+Appboy.prototype.alias = function(alias) {
+  var userId = alias.to().userId;
+  window.appboy.getUser().addAlias(userId, 'alias');
+};
+
+/**
  * Group.
  *
  * Sets the group Id for users.

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -316,6 +316,21 @@ describe('Appboy', function() {
       });
     });
 
+    describe('#alias', function() {
+      beforeEach(function() {
+        analytics.stub(window.appboy.ab.User.prototype, 'addAlias');
+      });
+
+      it('should send an event', function() {
+        analytics.alias({
+          previousId: 'oldName',
+          userId: 'newName'
+        });
+
+        analytics.called(window.appboy.ab.User.prototype.addAlias, 'newName', 'alias');
+      });
+    });
+
     describe('#track', function() {
       beforeEach(function() {
         analytics.stub(window.appboy, 'logCustomEvent');


### PR DESCRIPTION
Braze allows a name and a label, but Segment's `alias` doesn't currently
accept additional properties. For now, it'll just use the label 'alias'.

https://www.braze.com/academy/Data_and_Analytics/#user-aliases
https://www.braze.com/documentation/Web/#aliasing-users