### PR TITLE
If a message download is in-progress, wait until complete before logging a custom event

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 'use strict';
-
+  
 /**
  * Module dependencies.
  */
@@ -108,7 +108,7 @@ Appboy.prototype.initializeV1 = function(customEndpoint) {
     self.ready();
   });
 };
-  
+
 /**
  * Initialize v2.
  *
@@ -117,7 +117,7 @@ Appboy.prototype.initializeV1 = function(customEndpoint) {
 
 Appboy.prototype.initializeV2 = function(customEndpoint) {
   var options = this.options;
-  var userId = this.analytics.user().id();
+  var self = this;
   
   /* eslint-disable */
   +function (a, p, P, b, y) {
@@ -151,12 +151,106 @@ Appboy.prototype.initializeV2 = function(customEndpoint) {
   window.appboy.initialize(options.apiKey, config);
   
   if (options.automaticallyDisplayMessages) window.appboy.display.automaticallyShowNewInAppMessages();
-  if (userId) window.appboy.changeUser(userId);
-  
-  window.appboy.openSession();
+  this.load('v2', function() {
+    console.log("IBM_TEST: ready and changing user", userId);
+    var userId = self.analytics.user().id();
 
-  this.load('v2', this.ready);
+    if (userId) {
+      window.appboy.changeUser(userId, self._createMessagingReadyCallback(function() {
+        window.appboy.openSession();
+      }))
+    } else {
+      window.appboy.openSession(self._createMessagingReadyCallback());
+    }
+
+    self.ready();
+  });
 };
+
+Appboy.prototype._createMessagingReadyCallback = function(otherCallback) {
+  var self = this;
+
+  // return nothing for callback if not using v2
+  if (Number(self.options.version) !== 2) {
+    return undefined;
+  }
+
+  // is a download already in progress?
+  if (self._latestMessagingReadyCallback != null) {
+    console.log("IBM_TEST: message download is already in progress");
+    return otherCallback;
+  }
+
+  console.log("IBM_TEST: starting new message download");
+  self._latestMessagingReadyCallback = function latestMessageReadyCallback() {
+    // call the immediate callback if provided
+    if (otherCallback != null && typeof(otherCallback) === 'function') {
+      otherCallback();
+    }
+
+    // now notify the listeners if we're the latest callback
+
+
+    /*
+    // check if we're the latest callback
+    if (latestMessageReadyCallback !== self._latestMessagingReadyCallback) {
+      console.log("IBM_TEST: this callback is no longer attached to the latest messagingReadyCallback");
+      return;
+    }
+    */
+   console.log("IBM_TEST: message download complete");
+
+    // notify all the listeners
+    var listeners = self._mrListeners;
+    if (Array.isArray(listeners)) {
+      console.log("IBM_TEST: notifying all _messagingReady listeners, count:", self._mrListeners.length);
+      for (var i=0; i<listeners.length; i++) {
+        try {
+          var listener = listeners[i];
+          listener();
+        } catch(e) {
+          console.error("IBM TEST: messaging ready callback error", e);
+        }
+      }
+      console.log("IBM_TEST: clearing list of messaging ready listeners");
+      delete self._mrListeners;
+    } else {
+      console.log("IBM_TEST: no messaging ready listeners found");
+    }
+    delete self._latestMessagingReadyCallback;
+  }
+
+  // return new global callback to appboy function
+  return self._latestMessagingReadyCallback;
+}
+
+Appboy.prototype._messagingReady = function(listener) {
+  var self = this;
+
+  // if not v2, just notify the listener
+  if (Number(self.options.version) !== 2) {
+    listener();
+    return;
+  }
+
+  console.log("IBM_TEST: adding new listener to be notified when messages are ready");
+
+  // if nothing is in-flight, notify immediately
+  if (self._latestMessagingReadyCallback == null) {
+    console.log("IBM_TEST: no message downloads in-flight - notifying immediately");
+    listener();
+    return;
+  }
+
+  console.log("IBM_TEST: messages are being downloaded; adding to queue of listeners to be notified");
+  if (listener != null && typeof(listener) === 'function') {
+    if (!Array.isArray(self._mrListeners)) {
+      self._mrListeners = [];
+    }
+    self._mrListeners.push(listener);
+  }
+}
+
 
 // This is used to test window.appboy.initialize
 Appboy.prototype.initializeTester = function() {};
@@ -193,7 +287,8 @@ Appboy.prototype.identify = function(identify) {
   var phone = identify.phone();
   var traits = clone(identify.traits());
 
-  window.appboy.changeUser(userId);
+  console.log("IBM_TEST: calling identify", userId);
+  window.appboy.changeUser(userId, this._createMessagingReadyCallback());
   window.appboy.getUser().setAvatarImageUrl(avatar);
   window.appboy.getUser().setEmail(email);
   window.appboy.getUser().setFirstName(firstName);
@@ -231,10 +326,8 @@ Appboy.prototype.identify = function(identify) {
  */
 
 Appboy.prototype.group = function(group) {
-  var userId = group.userId();
   var groupIdKey = 'ab_segment_group_' + group.groupId();
 
-  window.appboy.changeUser(userId);
   window.appboy.getUser().setCustomUserAttribute(groupIdKey, true);
 };
 
@@ -258,8 +351,10 @@ Appboy.prototype.track = function(track) {
     delete properties[key];
   }, reserved);
 
-  window.appboy.changeUser(userId);
-  window.appboy.logCustomEvent(eventName, properties);
+  this._messagingReady(function() {
+    window.appboy.logCustomEvent(eventName, properties);
+  })
+
 };
 
 /**
@@ -276,13 +371,13 @@ Appboy.prototype.page = function(page) {
   if (!settings.trackAllPages && !settings.trackNamedPages) return;
   if (settings.trackNamedPages && !page.name()) return;
 
-  var userId = page.userId();
   var pageEvent = page.track(page.fullName());
   var eventName = pageEvent.event();
   var properties = page.properties();
 
-  window.appboy.changeUser(userId);
-  window.appboy.logCustomEvent(eventName, properties);
+  this._messagingReady(function() {
+    window.appboy.logCustomEvent("Loaded a Page", properties);
+  })
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -376,7 +376,7 @@ Appboy.prototype.page = function(page) {
   var properties = page.properties();
 
   this._messagingReady(function() {
-    window.appboy.logCustomEvent("Loaded a Page", properties);
+    window.appboy.logCustomEvent(eventName, properties);
   })
 };
 


### PR DESCRIPTION
Basically this keeps track of the callback in a `window.appboy` scoped var and provides a new function called `_messagingReady(callback)`.  Calls to `logCustomEvent()` can be wrapped as follows:

```js
this._messagingReady(function() {
  window.appboy.logCustomEvent(eventName, properties);
})
```
When the messages have been downloaded, the callback is invoked.  In testing simple pages, it seems to solve the race condition and make the integration more predictable.

For example, if a page instruments as follows:
```js
analytics.load("{writeKey}");
analytics.identify("{userId}")
analytics.page();
```
The above change will ensure all the Braze in-app messages have been downloaded before the page custom event is called on the SDK.