### PR TITLE
Have initialization hook into Braze callbacks

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -151,11 +151,32 @@ Appboy.prototype.initializeV2 = function(customEndpoint) {
   window.appboy.initialize(options.apiKey, config);
   
   if (options.automaticallyDisplayMessages) window.appboy.display.automaticallyShowNewInAppMessages();
-  if (userId) window.appboy.changeUser(userId);
   
-  window.appboy.openSession();
-
-  this.load('v2', this.ready);
+  // Initialization of Appboy must proceed as follows:
+  //
+  // 1. Load Appboy's script onto the page. This is `this.load`.
+  // 2. If there is already a cached userId for this page, then invoke
+  //    `changeUser` with that userId. Do not proceed until the in-app messages
+  //    for that user are ready.
+  // 3. Invoke `openSession`. Do not proceed until the session is successfully
+  //    opened.
+  // 4. Mark the integration as ready. This is `self.ready`.
+  var self = this;
+  if (userId) {
+    this.load('v2', function() {
+      window.appboy.changeUser(userId, function() {
+        window.appboy.openSession(function() {
+          self.ready();
+        });
+      });
+    });
+  } else {
+    this.load('v2', function() {
+      window.appboy.openSession(function() {
+        self.ready();
+      });
+    });
+  }
 };
 
 // This is used to test window.appboy.initialize


### PR DESCRIPTION
The `v2` initialization of this integration operates with a synchronous mindset inherited from `v1` of the integration. In fact, the Braze `v2` SDK has callbacks which indicate, among other things, when in-app messaging is available.

It is important that this integration not invoke `ready()` until these in-app messages are ready. Otherwise, a race condition results, and users invoking `analytics.page()` are not guaranteed to see the appropriate in-app messages.

There remains another race condition in this integration -- the `changeUser` triggered by `.identify()` does not guarantee that a subsequent `analytics.page()` call will be deferred until the in-app messaging is ready. This race condition is outside the scope of this pull request.