### PR TITLE
Remove changeUser from track, page, group and completedOrder

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -252,10 +252,8 @@ Appboy.prototype.identify = function(identify) {
  */
 
 Appboy.prototype.group = function(group) {
-  var userId = this.analytics.user().id();
   var groupIdKey = 'ab_segment_group_' + group.groupId();
 
-  window.appboy.changeUser(userId);
   window.appboy.getUser().setCustomUserAttribute(groupIdKey, true);
 };
 
@@ -269,7 +267,6 @@ Appboy.prototype.group = function(group) {
  */
 
 Appboy.prototype.track = function(track) {
-  var userId = this.analytics.user().id();
   var eventName = track.event();
   var properties = track.properties();
   // remove reserved keys from custom event properties
@@ -279,7 +276,6 @@ Appboy.prototype.track = function(track) {
     delete properties[key];
   }, reserved);
 
-  window.appboy.changeUser(userId);
   window.appboy.logCustomEvent(eventName, properties);
 };
 
@@ -297,12 +293,10 @@ Appboy.prototype.page = function(page) {
   if (!settings.trackAllPages && !settings.trackNamedPages) return;
   if (settings.trackNamedPages && !page.name()) return;
 
-  var userId = this.analytics.user().id();
   var pageEvent = page.track(page.fullName());
   var eventName = pageEvent.event();
   var properties = page.properties();
 
-  window.appboy.changeUser(userId);
   window.appboy.logCustomEvent(eventName, properties);
 };
 
@@ -319,12 +313,9 @@ Appboy.prototype.page = function(page) {
 
 
 Appboy.prototype.orderCompleted = function(track) {
-  var userId = this.analytics.user().id();
   var products = track.products();
   var currencyCode = track.currency();
   var purchaseProperties = track.properties();
-
-  window.appboy.changeUser(userId);
 
   // remove reduntant properties
   del(purchaseProperties, 'products');

--- a/lib/index.js
+++ b/lib/index.js
@@ -48,7 +48,7 @@ Appboy.prototype.initialize = function() {
   } else if (options.datacenter === 'eu') {
     customEndpoint = 'https://sdk.fra-01.braze.eu/api/v3';
   }
-  
+
   if (Number(options.version) === 2) {
     this.initializeV2(customEndpoint);
   } else {
@@ -72,7 +72,7 @@ Appboy.prototype.initializeV1 = function(customEndpoint) {
     window.appboy={};for(var s="destroy toggleAppboyLogging setLogger openSession changeUser requestImmediateDataFlush requestFeedRefresh subscribeToFeedUpdates logCardImpressions logCardClick logFeedDisplayed requestInAppMessageRefresh logInAppMessageImpression logInAppMessageClick logInAppMessageButtonClick subscribeToNewInAppMessages removeSubscription removeAllSubscriptions logCustomEvent logPurchase isPushSupported isPushBlocked isPushGranted isPushPermissionGranted registerAppboyPushMessages unregisterAppboyPushMessages submitFeedback ab ab.User ab.User.Genders ab.User.NotificationSubscriptionTypes ab.User.prototype.getUserId ab.User.prototype.setFirstName ab.User.prototype.setLastName ab.User.prototype.setEmail ab.User.prototype.setGender ab.User.prototype.setDateOfBirth ab.User.prototype.setCountry ab.User.prototype.setHomeCity ab.User.prototype.setEmailNotificationSubscriptionType ab.User.prototype.setPushNotificationSubscriptionType ab.User.prototype.setPhoneNumber ab.User.prototype.setAvatarImageUrl ab.User.prototype.setLastKnownLocation ab.User.prototype.setUserAttribute ab.User.prototype.setCustomUserAttribute ab.User.prototype.addToCustomAttributeArray ab.User.prototype.removeFromCustomAttributeArray ab.User.prototype.incrementCustomUserAttribute ab.InAppMessage ab.InAppMessage.SlideFrom ab.InAppMessage.ClickAction ab.InAppMessage.DismissType ab.InAppMessage.OpenTarget ab.InAppMessage.ImageStyle ab.InAppMessage.Orientation ab.InAppMessage.CropType ab.InAppMessage.prototype.subscribeToClickedEvent ab.InAppMessage.prototype.subscribeToDismissedEvent ab.InAppMessage.prototype.removeSubscription ab.InAppMessage.prototype.removeAllSubscriptions ab.InAppMessage.Button ab.InAppMessage.Button.prototype.subscribeToClickedEvent ab.InAppMessage.Button.prototype.removeSubscription ab.InAppMessage.Button.prototype.removeAllSubscriptions ab.SlideUpMessage ab.ModalMessage ab.FullScreenMessage ab.ControlMessage ab.Feed ab.Feed.prototype.getUnreadCardCount ab.Card ab.ClassicCard ab.CaptionedImage ab.Banner ab.WindowUtils display display.automaticallyShowNewInAppMessages display.showInAppMessage display.showFeed display.destroyFeed display.toggleFeed sharedLib".split(" "),i=0;i<s.length;i++){for(var k=appboy,l=s[i].split("."),j=0;j<l.length-1;j++)k=k[l[j]];k[l[j]]=function(){console&&console.error("The Appboy SDK has not yet been loaded.")}}appboy.initialize=function(){console&&console.error("Appboy cannot be loaded - this is usually due to strict corporate firewalls or ad blockers.")};appboy.getUser=function(){return new appboy.ab.User};appboy.getCachedFeed=function(){return new appboy.ab.Feed};
   }(document, 'script', 'link');
   /* eslint-enable */
-  
+
   // this is used to test this.loaded
   this._shim = window.appboy.initialize;
 
@@ -108,7 +108,7 @@ Appboy.prototype.initializeV1 = function(customEndpoint) {
     self.ready();
   });
 };
-  
+
 /**
  * Initialize v2.
  *
@@ -118,7 +118,7 @@ Appboy.prototype.initializeV1 = function(customEndpoint) {
 Appboy.prototype.initializeV2 = function(customEndpoint) {
   var options = this.options;
   var userId = this.analytics.user().id();
-  
+
   /* eslint-disable */
   +function (a, p, P, b, y) {
     window.appboy = {}; window.appboyQueue = [];
@@ -146,12 +146,12 @@ Appboy.prototype.initializeV2 = function(customEndpoint) {
   };
 
   if (customEndpoint) config.baseUrl = customEndpoint;
-  
+
   this.initializeTester(options.apiKey, config);
   window.appboy.initialize(options.apiKey, config);
-  
+
   if (options.automaticallyDisplayMessages) window.appboy.display.automaticallyShowNewInAppMessages();
-  
+
   // Initialization of Appboy must proceed as follows:
   //
   // 1. Load Appboy's script onto the page. This is `this.load`.
@@ -252,7 +252,7 @@ Appboy.prototype.identify = function(identify) {
  */
 
 Appboy.prototype.group = function(group) {
-  var userId = group.userId();
+  var userId = this.analytics.user().id();
   var groupIdKey = 'ab_segment_group_' + group.groupId();
 
   window.appboy.changeUser(userId);
@@ -269,7 +269,7 @@ Appboy.prototype.group = function(group) {
  */
 
 Appboy.prototype.track = function(track) {
-  var userId = track.userId();
+  var userId = this.analytics.user().id();
   var eventName = track.event();
   var properties = track.properties();
   // remove reserved keys from custom event properties
@@ -297,7 +297,7 @@ Appboy.prototype.page = function(page) {
   if (!settings.trackAllPages && !settings.trackNamedPages) return;
   if (settings.trackNamedPages && !page.name()) return;
 
-  var userId = page.userId();
+  var userId = this.analytics.user().id();
   var pageEvent = page.track(page.fullName());
   var eventName = pageEvent.event();
   var properties = page.properties();
@@ -319,7 +319,7 @@ Appboy.prototype.page = function(page) {
 
 
 Appboy.prototype.orderCompleted = function(track) {
-  var userId = track.userId();
+  var userId = this.analytics.user().id();
   var products = track.products();
   var currencyCode = track.currency();
   var purchaseProperties = track.properties();


### PR DESCRIPTION
Currently, the Braze `Analytics.js` integration does not properly retrieve the` userId` on `track`, `group`, `page`, and `completedOrder` events. When debugging Braze and enabling Braze native logging, the Braze method that uses the value for `page.userId();` is saying there is no `userId`:

![image](https://user-images.githubusercontent.com/7421111/43427394-2b76a356-940e-11e8-9fe1-5ab1c4da317e.png)


Confirmed that `analytics.user().id();` returns a value for `userId` on the client.

Prateek mentioned that Analytics.js doesn't set the `userId` on most event types. Exceptions are `identify` and `alias`.

For example, `page.userId` on the client will never return a `userId` (regardless of whether identify has been called previously or not) because `Analytics.js` does not set `userId` on the [page facade ](https://github.com/segmentio/analytics.js-core/blob/master/lib/analytics.js#L517).

After speaking with the Braze team, they mentioned that we should only be calling `changeUser` on `identify`. 

This PR removes the mapping of `userId` and calling `changeUser` on non-identify events. 

JIRA: https://segment.atlassian.net/browse/GA-418
CC: https://segment.atlassian.net/browse/CC-1084