### PR TITLE
Queue up logCustomEvent until in-app messaging is ready

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -372,12 +372,17 @@ Appboy.prototype.orderCompleted = function(track) {
   del(purchaseProperties, 'currency');
 
   // we have to make a separate call to appboy for each product
+  var self = this;
   each(function(product) {
     var track = new Track({ properties: product });
     var productId = track.productId();
     var price = track.price();
     var quantity = track.quantity();
-    window.appboy.logPurchase(productId, price, currencyCode, quantity, purchaseProperties);
+
+    // Fire a logPurchase once in-app messaging is ready.
+    self._onMessagingReady(function() {
+      window.appboy.logPurchase(productId, price, currencyCode, quantity, purchaseProperties);
+    });
   }, products);
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,6 +49,9 @@ Appboy.prototype.initialize = function() {
     customEndpoint = 'https://sdk.fra-01.braze.eu/api/v3';
   }
 
+  this._messagingReady = false;
+  this._messagingReadyQueue = [];
+
   if (Number(options.version) === 2) {
     this.initializeV2(customEndpoint);
   } else {
@@ -164,7 +167,7 @@ Appboy.prototype.initializeV2 = function(customEndpoint) {
   var self = this;
   if (userId) {
     this.load('v2', function() {
-      window.appboy.changeUser(userId, function() {
+      self._changeUser(userId, function() {
         window.appboy.openSession(function() {
           self.ready();
         });
@@ -181,6 +184,46 @@ Appboy.prototype.initializeV2 = function(customEndpoint) {
 
 // This is used to test window.appboy.initialize
 Appboy.prototype.initializeTester = function() {};
+
+// A wrapper around `appboy.changeUser` that supports a queued system for
+// waiting for in-app messages.
+Appboy.prototype._changeUser = function(userId, callback) {
+  // If we're using SDK v2, then messaging should be delayed -- `messagingReady`
+  // should be false. With SDK v1, messaging is ready right away.
+  this._messagingReady = Number(this.options.version) !== 2;
+
+  // Do not invoke the callback until messaging is ready.
+  this._onMessagingReady(callback);
+  
+  // Actually perform the `changeUser` call. The callback we pass to
+  // `appboy.changeUser` will be invoked when in-app messaging is ready.
+  var self = this;
+  window.appboy.changeUser(userId, function() {
+    // Invoke all the callbacks awaiting for in-app messages to be ready. These
+    // callbacks were all enqueued by calling `_onMessagingReady`.
+    each(function(callback) {
+      callback();
+    }, self._messagingReadyQueue);
+
+    // We have processed all awaiting callbacks. Future calls to
+    // `_onMessagingReady` can have their callbacks invoked immediately, at
+    // least until the next time we call `_changeUser` and new in-app messages
+    // must be downloaded.
+    self._messagingReady = true;
+    self._messagingReadyQueue = [];
+  });
+};
+
+// If in-app messages are available, the passed callback will be invoked
+// immediately. If we are still downloading in-app messaging, then the passed
+// callback will not be called until the messaging is ready.
+Appboy.prototype._onMessagingReady = function(callback) {
+  if (this._messagingReady) {
+    callback();
+  } else {
+    this._messagingReadyQueue.push(callback);
+  }
+};
 
 /**
  * Loaded?
@@ -214,32 +257,33 @@ Appboy.prototype.identify = function(identify) {
   var phone = identify.phone();
   var traits = clone(identify.traits());
 
-  window.appboy.changeUser(userId);
-  window.appboy.getUser().setAvatarImageUrl(avatar);
-  window.appboy.getUser().setEmail(email);
-  window.appboy.getUser().setFirstName(firstName);
-  window.appboy.getUser().setGender(getGender(gender));
-  window.appboy.getUser().setLastName(lastName);
-  window.appboy.getUser().setPhoneNumber(phone);
-  if (address) {
-    window.appboy.getUser().setCountry(address.country);
-    window.appboy.getUser().setHomeCity(address.city);
-  }
-  if (birthday) {
-    window.appboy.getUser().setDateOfBirth(birthday.getUTCFullYear(), birthday.getUTCMonth() + 1, birthday.getUTCDate());
-  }
-
-  // delete all the standard traits from traits clone so that we can use appboy's setCustomAttribute on non-standard traits
-  // also remove all reserved keys so we dont set them as custom attributes, otherwise Appboy rejects the entire event
-  // https://www.appboy.com/documentation/Platform_Wide/#reserved-keys
-  var reserved = ['avatar', 'address', 'birthday', 'email', 'id', 'firstName', 'gender', 'lastName', 'phone', 'facebook', 'twitter', 'first_name', 'last_name', 'dob', 'external_id', 'country', 'home_city', 'bio', 'gender', 'phone', 'email_subscribe', 'push_subscribe'];
-  each(function(key) {
-    delete traits[key];
-  }, reserved);
-
-  each(function(value, key) {
-    window.appboy.getUser().setCustomUserAttribute(key, value);
-  }, traits);
+  this._changeUser(userId, function() {
+    window.appboy.getUser().setAvatarImageUrl(avatar);
+    window.appboy.getUser().setEmail(email);
+    window.appboy.getUser().setFirstName(firstName);
+    window.appboy.getUser().setGender(getGender(gender));
+    window.appboy.getUser().setLastName(lastName);
+    window.appboy.getUser().setPhoneNumber(phone);
+    if (address) {
+      window.appboy.getUser().setCountry(address.country);
+      window.appboy.getUser().setHomeCity(address.city);
+    }
+    if (birthday) {
+      window.appboy.getUser().setDateOfBirth(birthday.getUTCFullYear(), birthday.getUTCMonth() + 1, birthday.getUTCDate());
+    }
+  
+    // delete all the standard traits from traits clone so that we can use appboy's setCustomAttribute on non-standard traits
+    // also remove all reserved keys so we dont set them as custom attributes, otherwise Appboy rejects the entire event
+    // https://www.appboy.com/documentation/Platform_Wide/#reserved-keys
+    var reserved = ['avatar', 'address', 'birthday', 'email', 'id', 'firstName', 'gender', 'lastName', 'phone', 'facebook', 'twitter', 'first_name', 'last_name', 'dob', 'external_id', 'country', 'home_city', 'bio', 'gender', 'phone', 'email_subscribe', 'push_subscribe'];
+    each(function(key) {
+      delete traits[key];
+    }, reserved);
+  
+    each(function(value, key) {
+      window.appboy.getUser().setCustomUserAttribute(key, value);
+    }, traits);  
+  });
 };
 
 /**
@@ -276,7 +320,10 @@ Appboy.prototype.track = function(track) {
     delete properties[key];
   }, reserved);
 
-  window.appboy.logCustomEvent(eventName, properties);
+  // Fire a logCustomEvent once in-app messaging is ready.
+  this._onMessagingReady(function() {
+    window.appboy.logCustomEvent(eventName, properties);
+  });
 };
 
 /**
@@ -297,7 +344,10 @@ Appboy.prototype.page = function(page) {
   var eventName = pageEvent.event();
   var properties = page.properties();
 
-  window.appboy.logCustomEvent(eventName, properties);
+  // Fire a logCustomEvent once in-app messaging is ready.
+  this._onMessagingReady(function() {
+    window.appboy.logCustomEvent(eventName, properties);
+  });
 };
 
 /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -396,15 +396,18 @@ describe('Appboy', function() {
             }
           ]
         });
-        analytics.called(window.appboy.logPurchase, '507f1f77bcf86cd799439011', 19.23, 'USD', 1, {
-          total: 30,
-          revenue: 25,
-          shipping: 3
-        });
-        analytics.called(window.appboy.logPurchase, '505bd76785ebb509fc183733', 3, 'USD', 2, {
-          total: 30,
-          revenue: 25,
-          shipping: 3
+
+        appboy._onMessagingReady(function() {
+          analytics.called(window.appboy.logPurchase, '507f1f77bcf86cd799439011', 19.23, 'USD', 1, {
+            total: 30,
+            revenue: 25,
+            shipping: 3
+          });
+          analytics.called(window.appboy.logPurchase, '505bd76785ebb509fc183733', 3, 'USD', 2, {
+            total: 30,
+            revenue: 25,
+            shipping: 3
+          });
         });
       });
 
@@ -421,8 +424,11 @@ describe('Appboy', function() {
             }
           ]
         });
-        analytics.called(window.appboy.logPurchase, '507f1f77bcf86cd799439011', 17.38);
-        analytics.called(window.appboy.logPurchase, '505bd76785ebb509fc183733', 3);
+
+        appboy._onMessagingReady(function() {
+          analytics.called(window.appboy.logPurchase, '507f1f77bcf86cd799439011', 17.38);
+          analytics.called(window.appboy.logPurchase, '505bd76785ebb509fc183733', 3);
+        });
       });
     });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -335,7 +335,10 @@ describe('Appboy', function() {
 
       it('should send an event', function() {
         analytics.track('event');
-        analytics.called(window.appboy.logCustomEvent, 'event');
+
+        appboy._onMessagingReady(function() {
+          analytics.called(window.appboy.logCustomEvent, 'event');
+        });
       });
 
       it('should send all properties', function() {
@@ -344,10 +347,13 @@ describe('Appboy', function() {
           spiritAnimal: 'rihanna',
           best_friend: 'han'
         });
-        analytics.called(window.appboy.logCustomEvent, 'event with properties', {
-          nickname: 'noonz',
-          spiritAnimal: 'rihanna',
-          best_friend: 'han'
+
+        appboy._onMessagingReady(function() {
+          analytics.called(window.appboy.logCustomEvent, 'event with properties', {
+            nickname: 'noonz',
+            spiritAnimal: 'rihanna',
+            best_friend: 'han'
+          });
         });
       });
 
@@ -359,7 +365,10 @@ describe('Appboy', function() {
           currency: 'usd',
           quantity: '123'
         });
-        analytics.called(window.appboy.logCustomEvent, 'event with properties', {});
+
+        appboy._onMessagingReady(function() {
+          analytics.called(window.appboy.logCustomEvent, 'event with properties', {});
+        });
       });
 
       it('should call logPurchase for each product in a Completed Order event', function() {
@@ -425,23 +434,35 @@ describe('Appboy', function() {
       it('should send a page view if trackAllPages is enabled', function() {
         appboy.options.trackAllPages = true;
         analytics.page();
-        analytics.called(window.appboy.logCustomEvent, 'Loaded a Page');
+
+        appboy._onMessagingReady(function() {
+          analytics.called(window.appboy.logCustomEvent, 'Loaded a Page');
+        });
       });
 
       it('should send a page view if trackNamedPages is enabled', function() {
         appboy.options.trackNamedPages = true;
         analytics.page('Home');
-        analytics.called(window.appboy.logCustomEvent, 'Viewed Home Page');
+
+        appboy._onMessagingReady(function() {
+          analytics.called(window.appboy.logCustomEvent, 'Viewed Home Page');
+        });
       });
 
       it('should not send a page view if trackAllPages and trackNamedPages are disabled', function() {
         analytics.page('Home');
-        analytics.didNotCall(window.appboy.logCustomEvent);
+
+        appboy._onMessagingReady(function() {
+          analytics.didNotCall(window.appboy.logCustomEvent);
+        });
       });
 
       it('should not send a page view if trackNamedPages is enabled and name is null', function() {
         analytics.page();
-        analytics.didNotCall(window.appboy.logCustomEvent);
+
+        appboy._onMessagingReady(function() {
+          analytics.didNotCall(window.appboy.logCustomEvent);
+        });
       });
 
       it('should send all properties', function() {
@@ -450,13 +471,16 @@ describe('Appboy', function() {
           title: 'noonz',
           url: 'www.google.com'
         });
-        analytics.called(window.appboy.logCustomEvent, 'Viewed Home Page', {
-          title: 'noonz',
-          url: 'www.google.com',
-          name: 'Home',
-          path: window.location.pathname,
-          referrer: window.document.referrer,
-          search: ''
+
+        appboy._onMessagingReady(function() {
+          analytics.called(window.appboy.logCustomEvent, 'Viewed Home Page', {
+            title: 'noonz',
+            url: 'www.google.com',
+            name: 'Home',
+            path: window.location.pathname,
+            referrer: window.document.referrer,
+            search: ''
+          });
         });
       });
     });


### PR DESCRIPTION
This PR ensures that calls to `logCustomEvent` won't happen until the appropriate in-app messaging is ready.

With this PR, we'll keep track of whether we are currently downloading in-app messaging. If we ever are, we queue up calls to `logCustomEvent`; once in-app messaging is ready, we'll flush that queue.

This change required changing our tests to hook into the internal `_onMessagingReady` method. This is non-ideal, but I can think of no easier way to have tests synchronize with Appboy's internal events system.

_Note:_ The above explanation applies to `logPurchase` as well.

Closes #25.