### PR TITLE
Revert changeUser change, release only initialization updates

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+1.8.0 / 2018-08-02
+==================
+
+* Revert "Remove changeUser from track, page, group and completedOrder" (#27).
+
 1.7.0 / 2018-07-31
 ==================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -48,7 +48,7 @@ Appboy.prototype.initialize = function() {
   } else if (options.datacenter === 'eu') {
     customEndpoint = 'https://sdk.fra-01.braze.eu/api/v3';
   }
-
+  
   if (Number(options.version) === 2) {
     this.initializeV2(customEndpoint);
   } else {
@@ -72,7 +72,7 @@ Appboy.prototype.initializeV1 = function(customEndpoint) {
     window.appboy={};for(var s="destroy toggleAppboyLogging setLogger openSession changeUser requestImmediateDataFlush requestFeedRefresh subscribeToFeedUpdates logCardImpressions logCardClick logFeedDisplayed requestInAppMessageRefresh logInAppMessageImpression logInAppMessageClick logInAppMessageButtonClick subscribeToNewInAppMessages removeSubscription removeAllSubscriptions logCustomEvent logPurchase isPushSupported isPushBlocked isPushGranted isPushPermissionGranted registerAppboyPushMessages unregisterAppboyPushMessages submitFeedback ab ab.User ab.User.Genders ab.User.NotificationSubscriptionTypes ab.User.prototype.getUserId ab.User.prototype.setFirstName ab.User.prototype.setLastName ab.User.prototype.setEmail ab.User.prototype.setGender ab.User.prototype.setDateOfBirth ab.User.prototype.setCountry ab.User.prototype.setHomeCity ab.User.prototype.setEmailNotificationSubscriptionType ab.User.prototype.setPushNotificationSubscriptionType ab.User.prototype.setPhoneNumber ab.User.prototype.setAvatarImageUrl ab.User.prototype.setLastKnownLocation ab.User.prototype.setUserAttribute ab.User.prototype.setCustomUserAttribute ab.User.prototype.addToCustomAttributeArray ab.User.prototype.removeFromCustomAttributeArray ab.User.prototype.incrementCustomUserAttribute ab.InAppMessage ab.InAppMessage.SlideFrom ab.InAppMessage.ClickAction ab.InAppMessage.DismissType ab.InAppMessage.OpenTarget ab.InAppMessage.ImageStyle ab.InAppMessage.Orientation ab.InAppMessage.CropType ab.InAppMessage.prototype.subscribeToClickedEvent ab.InAppMessage.prototype.subscribeToDismissedEvent ab.InAppMessage.prototype.removeSubscription ab.InAppMessage.prototype.removeAllSubscriptions ab.InAppMessage.Button ab.InAppMessage.Button.prototype.subscribeToClickedEvent ab.InAppMessage.Button.prototype.removeSubscription ab.InAppMessage.Button.prototype.removeAllSubscriptions ab.SlideUpMessage ab.ModalMessage ab.FullScreenMessage ab.ControlMessage ab.Feed ab.Feed.prototype.getUnreadCardCount ab.Card ab.ClassicCard ab.CaptionedImage ab.Banner ab.WindowUtils display display.automaticallyShowNewInAppMessages display.showInAppMessage display.showFeed display.destroyFeed display.toggleFeed sharedLib".split(" "),i=0;i<s.length;i++){for(var k=appboy,l=s[i].split("."),j=0;j<l.length-1;j++)k=k[l[j]];k[l[j]]=function(){console&&console.error("The Appboy SDK has not yet been loaded.")}}appboy.initialize=function(){console&&console.error("Appboy cannot be loaded - this is usually due to strict corporate firewalls or ad blockers.")};appboy.getUser=function(){return new appboy.ab.User};appboy.getCachedFeed=function(){return new appboy.ab.Feed};
   }(document, 'script', 'link');
   /* eslint-enable */
-
+  
   // this is used to test this.loaded
   this._shim = window.appboy.initialize;
 
@@ -108,7 +108,7 @@ Appboy.prototype.initializeV1 = function(customEndpoint) {
     self.ready();
   });
 };
-
+  
 /**
  * Initialize v2.
  *
@@ -118,7 +118,7 @@ Appboy.prototype.initializeV1 = function(customEndpoint) {
 Appboy.prototype.initializeV2 = function(customEndpoint) {
   var options = this.options;
   var userId = this.analytics.user().id();
-
+  
   /* eslint-disable */
   +function (a, p, P, b, y) {
     window.appboy = {}; window.appboyQueue = [];
@@ -146,12 +146,12 @@ Appboy.prototype.initializeV2 = function(customEndpoint) {
   };
 
   if (customEndpoint) config.baseUrl = customEndpoint;
-
+  
   this.initializeTester(options.apiKey, config);
   window.appboy.initialize(options.apiKey, config);
-
+  
   if (options.automaticallyDisplayMessages) window.appboy.display.automaticallyShowNewInAppMessages();
-
+  
   // Initialization of Appboy must proceed as follows:
   //
   // 1. Load Appboy's script onto the page. This is `this.load`.
@@ -252,8 +252,10 @@ Appboy.prototype.identify = function(identify) {
  */
 
 Appboy.prototype.group = function(group) {
+  var userId = group.userId();
   var groupIdKey = 'ab_segment_group_' + group.groupId();
 
+  window.appboy.changeUser(userId);
   window.appboy.getUser().setCustomUserAttribute(groupIdKey, true);
 };
 
@@ -267,6 +269,7 @@ Appboy.prototype.group = function(group) {
  */
 
 Appboy.prototype.track = function(track) {
+  var userId = track.userId();
   var eventName = track.event();
   var properties = track.properties();
   // remove reserved keys from custom event properties
@@ -276,6 +279,7 @@ Appboy.prototype.track = function(track) {
     delete properties[key];
   }, reserved);
 
+  window.appboy.changeUser(userId);
   window.appboy.logCustomEvent(eventName, properties);
 };
 
@@ -293,10 +297,12 @@ Appboy.prototype.page = function(page) {
   if (!settings.trackAllPages && !settings.trackNamedPages) return;
   if (settings.trackNamedPages && !page.name()) return;
 
+  var userId = page.userId();
   var pageEvent = page.track(page.fullName());
   var eventName = pageEvent.event();
   var properties = page.properties();
 
+  window.appboy.changeUser(userId);
   window.appboy.logCustomEvent(eventName, properties);
 };
 
@@ -313,9 +319,12 @@ Appboy.prototype.page = function(page) {
 
 
 Appboy.prototype.orderCompleted = function(track) {
+  var userId = track.userId();
   var products = track.products();
   var currencyCode = track.currency();
   var purchaseProperties = track.properties();
+
+  window.appboy.changeUser(userId);
 
   // remove reduntant properties
   del(purchaseProperties, 'products');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-appboy",
   "description": "The Appboy analytics.js integration.",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",


### PR DESCRIPTION
After shipping changes to the integration ( #30 ) we saw a drastic decline in errors in our internal metrics. While this seems great, it was unexpected behavior.

We decided to rollback to better understand and verify that the error rate drop is not impacting customers. This release rolls back changes that removed `changeUser` from being called on `track`, `page` and `orderCompleted` events. 

We decided to rollback in the order of shipping first updates to the initialization (#26) because if there is in fact a problem with initialization, there is a larger discussion and debugging effort to be had.

If removing `changeUser` causes drops in error rates, then we would be ok with the changes as there is an expectation that the current integration is throwing errors trying to call `appboy.changeUser(undefined)`. 