### PR TITLE
Debug errors in calls to changeUser

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -48,7 +48,7 @@ Appboy.prototype.initialize = function() {
   } else if (options.datacenter === 'eu') {
     customEndpoint = 'https://sdk.fra-01.braze.eu/api/v3';
   }
-
+  
   if (Number(options.version) === 2) {
     this.initializeV2(customEndpoint);
   } else {
@@ -72,7 +72,7 @@ Appboy.prototype.initializeV1 = function(customEndpoint) {
     window.appboy={};for(var s="destroy toggleAppboyLogging setLogger openSession changeUser requestImmediateDataFlush requestFeedRefresh subscribeToFeedUpdates logCardImpressions logCardClick logFeedDisplayed requestInAppMessageRefresh logInAppMessageImpression logInAppMessageClick logInAppMessageButtonClick subscribeToNewInAppMessages removeSubscription removeAllSubscriptions logCustomEvent logPurchase isPushSupported isPushBlocked isPushGranted isPushPermissionGranted registerAppboyPushMessages unregisterAppboyPushMessages submitFeedback ab ab.User ab.User.Genders ab.User.NotificationSubscriptionTypes ab.User.prototype.getUserId ab.User.prototype.setFirstName ab.User.prototype.setLastName ab.User.prototype.setEmail ab.User.prototype.setGender ab.User.prototype.setDateOfBirth ab.User.prototype.setCountry ab.User.prototype.setHomeCity ab.User.prototype.setEmailNotificationSubscriptionType ab.User.prototype.setPushNotificationSubscriptionType ab.User.prototype.setPhoneNumber ab.User.prototype.setAvatarImageUrl ab.User.prototype.setLastKnownLocation ab.User.prototype.setUserAttribute ab.User.prototype.setCustomUserAttribute ab.User.prototype.addToCustomAttributeArray ab.User.prototype.removeFromCustomAttributeArray ab.User.prototype.incrementCustomUserAttribute ab.InAppMessage ab.InAppMessage.SlideFrom ab.InAppMessage.ClickAction ab.InAppMessage.DismissType ab.InAppMessage.OpenTarget ab.InAppMessage.ImageStyle ab.InAppMessage.Orientation ab.InAppMessage.CropType ab.InAppMessage.prototype.subscribeToClickedEvent ab.InAppMessage.prototype.subscribeToDismissedEvent ab.InAppMessage.prototype.removeSubscription ab.InAppMessage.prototype.removeAllSubscriptions ab.InAppMessage.Button ab.InAppMessage.Button.prototype.subscribeToClickedEvent ab.InAppMessage.Button.prototype.removeSubscription ab.InAppMessage.Button.prototype.removeAllSubscriptions ab.SlideUpMessage ab.ModalMessage ab.FullScreenMessage ab.ControlMessage ab.Feed ab.Feed.prototype.getUnreadCardCount ab.Card ab.ClassicCard ab.CaptionedImage ab.Banner ab.WindowUtils display display.automaticallyShowNewInAppMessages display.showInAppMessage display.showFeed display.destroyFeed display.toggleFeed sharedLib".split(" "),i=0;i<s.length;i++){for(var k=appboy,l=s[i].split("."),j=0;j<l.length-1;j++)k=k[l[j]];k[l[j]]=function(){console&&console.error("The Appboy SDK has not yet been loaded.")}}appboy.initialize=function(){console&&console.error("Appboy cannot be loaded - this is usually due to strict corporate firewalls or ad blockers.")};appboy.getUser=function(){return new appboy.ab.User};appboy.getCachedFeed=function(){return new appboy.ab.Feed};
   }(document, 'script', 'link');
   /* eslint-enable */
-
+  
   // this is used to test this.loaded
   this._shim = window.appboy.initialize;
 
@@ -108,7 +108,7 @@ Appboy.prototype.initializeV1 = function(customEndpoint) {
     self.ready();
   });
 };
-
+  
 /**
  * Initialize v2.
  *
@@ -118,7 +118,7 @@ Appboy.prototype.initializeV1 = function(customEndpoint) {
 Appboy.prototype.initializeV2 = function(customEndpoint) {
   var options = this.options;
   var userId = this.analytics.user().id();
-
+  
   /* eslint-disable */
   +function (a, p, P, b, y) {
     window.appboy = {}; window.appboyQueue = [];
@@ -146,37 +146,16 @@ Appboy.prototype.initializeV2 = function(customEndpoint) {
   };
 
   if (customEndpoint) config.baseUrl = customEndpoint;
-
+  
   this.initializeTester(options.apiKey, config);
   window.appboy.initialize(options.apiKey, config);
-
+  
   if (options.automaticallyDisplayMessages) window.appboy.display.automaticallyShowNewInAppMessages();
+  if (userId) window.appboy.changeUser(userId);
+  
+  window.appboy.openSession();
 
-  // Initialization of Appboy must proceed as follows:
-  //
-  // 1. Load Appboy's script onto the page. This is `this.load`.
-  // 2. If there is already a cached userId for this page, then invoke
-  //    `changeUser` with that userId. Do not proceed until the in-app messages
-  //    for that user are ready.
-  // 3. Invoke `openSession`. Do not proceed until the session is successfully
-  //    opened.
-  // 4. Mark the integration as ready. This is `self.ready`.
-  var self = this;
-  if (userId) {
-    this.load('v2', function() {
-      window.appboy.changeUser(userId, function() {
-        window.appboy.openSession(function() {
-          self.ready();
-        });
-      });
-    });
-  } else {
-    this.load('v2', function() {
-      window.appboy.openSession(function() {
-        self.ready();
-      });
-    });
-  }
+  this.load('v2', this.ready);
 };
 
 // This is used to test window.appboy.initialize
@@ -252,8 +231,10 @@ Appboy.prototype.identify = function(identify) {
  */
 
 Appboy.prototype.group = function(group) {
+  var userId = group.userId();
   var groupIdKey = 'ab_segment_group_' + group.groupId();
 
+  window.appboy.changeUser(userId);
   window.appboy.getUser().setCustomUserAttribute(groupIdKey, true);
 };
 
@@ -267,6 +248,7 @@ Appboy.prototype.group = function(group) {
  */
 
 Appboy.prototype.track = function(track) {
+  var userId = track.userId();
   var eventName = track.event();
   var properties = track.properties();
   // remove reserved keys from custom event properties
@@ -276,6 +258,7 @@ Appboy.prototype.track = function(track) {
     delete properties[key];
   }, reserved);
 
+  window.appboy.changeUser(userId);
   window.appboy.logCustomEvent(eventName, properties);
 };
 
@@ -293,10 +276,12 @@ Appboy.prototype.page = function(page) {
   if (!settings.trackAllPages && !settings.trackNamedPages) return;
   if (settings.trackNamedPages && !page.name()) return;
 
+  var userId = page.userId();
   var pageEvent = page.track(page.fullName());
   var eventName = pageEvent.event();
   var properties = page.properties();
 
+  window.appboy.changeUser(userId);
   window.appboy.logCustomEvent(eventName, properties);
 };
 
@@ -313,9 +298,12 @@ Appboy.prototype.page = function(page) {
 
 
 Appboy.prototype.orderCompleted = function(track) {
+  var userId = track.userId();
   var products = track.products();
   var currencyCode = track.currency();
   var purchaseProperties = track.properties();
+
+  window.appboy.changeUser(userId);
 
   // remove reduntant properties
   del(purchaseProperties, 'products');

--- a/lib/index.js
+++ b/lib/index.js
@@ -258,7 +258,14 @@ Appboy.prototype.track = function(track) {
     delete properties[key];
   }, reserved);
 
-  window.appboy.changeUser(userId);
+  // For temporary testing purposes, attempt to detect errors in calls to
+  // `changeUser`.
+  try {
+    window.appboy.changeUser(userId);
+  } catch (e) {
+    console.error(e);
+  }
+
   window.appboy.logCustomEvent(eventName, properties);
 };
 


### PR DESCRIPTION
This PR:

1. Resets the integration to the state it was in in version 1.6.0.
2. Wraps `changeUser` calls in `track` with try/catch.

This PR is not meant to be a permanent state of affairs. We're deploying this as a temporary measure, to ensure that other changes we're about to introduce aren't going to introduce regressions.