### PR TITLE
Updating Braze SDK to latest minor version v2.2 | PLATFORM-3353

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,7 @@ var Appboy = module.exports = integration('Appboy')
   .option('customEndpoint', '')
   .option('version', 1)
   .tag('v1', '<script src="https://js.appboycdn.com/web-sdk/1.6/appboy.min.js">')
-  .tag('v2', '<script src="https://js.appboycdn.com/web-sdk/2.1/appboy.min.js">');
+  .tag('v2', '<script src="https://js.appboycdn.com/web-sdk/2.2/appboy.min.js">');
 
 
 Appboy.prototype.initialize = function() {


### PR DESCRIPTION
Updating the braze SDK to pull the latest minor version. @anoonan can we not pin to just v2 major version so we don't need to hardcode update everytime they release a new minor update?